### PR TITLE
Fix custom dai version in peripheral tests

### DIFF
--- a/tests/test_examples_standalone.py
+++ b/tests/test_examples_standalone.py
@@ -83,6 +83,9 @@ def setup_env(
         depthai_version=depthai_version,
         depthai_nodes_version=depthai_nodes_version,
     )
+    logger.info(
+        "If depthai and depthai-nodes versions are not compatible then dependency resolver might fail."
+    )
     # Create a copy of the old requirements
     shutil.copyfile(requirements_path, base_dir / "requirements_old.txt")
     # Save new requirements


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
- Fixed how we setup environment for peripheral tests
- For standalone tests setting custom DAI which might not be compatible with the rest of the requirements.txt will not work

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable