### PR TITLE
feat: add .oakappignore to all examples

### DIFF
--- a/apps/conference-demos/rgb-depth-connections/.oakappignore
+++ b/apps/conference-demos/rgb-depth-connections/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/apps/default-app/.oakappignore
+++ b/apps/default-app/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/camera-controls/depth-driven-focus/.oakappignore
+++ b/camera-controls/depth-driven-focus/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/camera-controls/lossless-zooming/.oakappignore
+++ b/camera-controls/lossless-zooming/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/camera-controls/manual-camera-control/.oakappignore
+++ b/camera-controls/manual-camera-control/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/custom-frontend/raw-stream/.oakappignore
+++ b/custom-frontend/raw-stream/.oakappignore
@@ -1,29 +1,43 @@
-native
-README.md
-*.Dockerfile
-.gitignore
-.gitlab-ci.yml
-Dockerfile
-node_modules
-.cache
-
-*.oakapp
-
-# Python
-**/venv/
-**/.venv/
-**/.mypy_cache/
-**/.ruff_cache/
+# Python virtual environments
+venv/
+.venv/
 
 # Node.js
-**/node_modules/
+# ignore node_modules, it will be reinstalled in the container
+node_modules/
+
+# Docker files
+*.Dockerfile
+Dockerfile
+
+# Build artifacts
+.cache
+native
+
+# Multimedia files
+media/
+
+# Documentation
+README.md
 
 # VCS
-**/.git/
-**/.github/
-**/.gitlab/
+.gitignore
+.git/
+.github/
+.gitlab-ci.yml
+.gitlab/
+
+# The following files are ignored by default
+# uncomment a line if you explicitly need it
+
+# !*.oakapp
+
+# Python
+# !**/.mypy_cache/
+# !**/.ruff_cache/
 
 # IDE files
-**/.idea
-**/.vscode
-**/.zed
+# !**/.idea
+# !**/.vscode
+# !**/.zed
+

--- a/depth-measurement/3d-measurement/rgbd-pointcloud/.oakappignore
+++ b/depth-measurement/3d-measurement/rgbd-pointcloud/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/depth-measurement/calc-spatial-on-host/.oakappignore
+++ b/depth-measurement/calc-spatial-on-host/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/depth-measurement/stereo-on-host/.oakappignore
+++ b/depth-measurement/stereo-on-host/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/depth-measurement/stereo-runtime-configuration/.oakappignore
+++ b/depth-measurement/stereo-runtime-configuration/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/depth-measurement/triangulation/.oakappignore
+++ b/depth-measurement/triangulation/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/depth-measurement/wls-filter/.oakappignore
+++ b/depth-measurement/wls-filter/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/integrations/foxglove/.oakappignore
+++ b/integrations/foxglove/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/integrations/hub-snaps-events/.oakappignore
+++ b/integrations/hub-snaps-events/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/integrations/rerun/.oakappignore
+++ b/integrations/rerun/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/integrations/roboflow-integration/.oakappignore
+++ b/integrations/roboflow-integration/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/3D-detection/objectron/.oakappignore
+++ b/neural-networks/3D-detection/objectron/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/counting/crowdcounting/.oakappignore
+++ b/neural-networks/counting/crowdcounting/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/counting/people-counter/.oakappignore
+++ b/neural-networks/counting/people-counter/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/depth-estimation/crestereo-stereo-matching/.oakappignore
+++ b/neural-networks/depth-estimation/crestereo-stereo-matching/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/face-detection/age-gender/.oakappignore
+++ b/neural-networks/face-detection/age-gender/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/face-detection/blur-faces/.oakappignore
+++ b/neural-networks/face-detection/blur-faces/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/face-detection/emotion-recognition/.oakappignore
+++ b/neural-networks/face-detection/emotion-recognition/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/face-detection/face-mask-detection/.oakappignore
+++ b/neural-networks/face-detection/face-mask-detection/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/face-detection/fatigue-detection/.oakappignore
+++ b/neural-networks/face-detection/fatigue-detection/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/face-detection/gaze-estimation/.oakappignore
+++ b/neural-networks/face-detection/gaze-estimation/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/face-detection/head-posture-detection/.oakappignore
+++ b/neural-networks/face-detection/head-posture-detection/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/feature-detection/xfeat/.oakappignore
+++ b/neural-networks/feature-detection/xfeat/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/generic-example/.oakappignore
+++ b/neural-networks/generic-example/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/object-detection/human-machine-safety/.oakappignore
+++ b/neural-networks/object-detection/human-machine-safety/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/object-detection/social-distancing/.oakappignore
+++ b/neural-networks/object-detection/social-distancing/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/object-detection/spatial-detections/.oakappignore
+++ b/neural-networks/object-detection/spatial-detections/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/object-detection/text-blur/.oakappignore
+++ b/neural-networks/object-detection/text-blur/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/object-detection/yolo-host-decoding/.oakappignore
+++ b/neural-networks/object-detection/yolo-host-decoding/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/object-detection/yolo-p/.oakappignore
+++ b/neural-networks/object-detection/yolo-p/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/object-detection/yolo-world/.oakappignore
+++ b/neural-networks/object-detection/yolo-world/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/object-tracking/collision-avoidance/.oakappignore
+++ b/neural-networks/object-tracking/collision-avoidance/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/object-tracking/deepsort-tracking/.oakappignore
+++ b/neural-networks/object-tracking/deepsort-tracking/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/object-tracking/kalman/.oakappignore
+++ b/neural-networks/object-tracking/kalman/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/object-tracking/people-tracker/.oakappignore
+++ b/neural-networks/object-tracking/people-tracker/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/ocr/general-ocr/.oakappignore
+++ b/neural-networks/ocr/general-ocr/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/ocr/license-plate-recognition/.oakappignore
+++ b/neural-networks/ocr/license-plate-recognition/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/pose-estimation/animal-pose/.oakappignore
+++ b/neural-networks/pose-estimation/animal-pose/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/pose-estimation/hand-pose/.oakappignore
+++ b/neural-networks/pose-estimation/hand-pose/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/pose-estimation/human-pose/.oakappignore
+++ b/neural-networks/pose-estimation/human-pose/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/reidentification/human-reidentification/.oakappignore
+++ b/neural-networks/reidentification/human-reidentification/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/segmentation/blur-background/.oakappignore
+++ b/neural-networks/segmentation/blur-background/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/segmentation/depth-crop/.oakappignore
+++ b/neural-networks/segmentation/depth-crop/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/neural-networks/speech-recognition/whisper-tiny-en/.oakappignore
+++ b/neural-networks/speech-recognition/whisper-tiny-en/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/streaming/mjpeg-streaming/.oakappignore
+++ b/streaming/mjpeg-streaming/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/streaming/on-device-encoding/.oakappignore
+++ b/streaming/on-device-encoding/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/streaming/poe-mqtt/.oakappignore
+++ b/streaming/poe-mqtt/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/streaming/poe-tcp-streaming/.oakappignore
+++ b/streaming/poe-tcp-streaming/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/streaming/rtsp-streaming/.oakappignore
+++ b/streaming/rtsp-streaming/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/streaming/webrtc-streaming/.oakappignore
+++ b/streaming/webrtc-streaming/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/tutorials/camera-demo/.oakappignore
+++ b/tutorials/camera-demo/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/tutorials/camera-stereo-depth/.oakappignore
+++ b/tutorials/camera-stereo-depth/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/tutorials/custom-models/.oakappignore
+++ b/tutorials/custom-models/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/tutorials/display-detections/.oakappignore
+++ b/tutorials/display-detections/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/tutorials/full-fov-nn/.oakappignore
+++ b/tutorials/full-fov-nn/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/tutorials/play-encoded-stream/.oakappignore
+++ b/tutorials/play-encoded-stream/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/

--- a/tutorials/qr-with-tiling/.oakappignore
+++ b/tutorials/qr-with-tiling/.oakappignore
@@ -6,14 +6,7 @@ venv/
 # ignore node_modules, it will be reinstalled in the container
 node_modules/
 
-# Multimedia files
-media/
-
-# Documentation
-README.md
-
 # VCS
-.gitignore
 .git/
 .github/
 .gitlab/


### PR DESCRIPTION
## Purpose
This patch adds or modifies `.oakappignore` everywhere based on the newly introduced `.oakappignore` template.

_Note:_ I'll keep this as a draft till https://github.com/luxonis/oak-template/pull/2 is merged.

## Specification
Note that most examples use the template ignore file and only the `custom-frontend` apps have their ignore files updated (merged with the template).

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
I've tried building the default app as well as one of the custom-frontend apps locally (with a local venv and mypy cache) and inspected the resulting package - whether it properly excludes ignored files. 