### PR TITLE
Fixed padding for yolo-world postprocessing

### DIFF
--- a/custom-frontend/dynamic-yolo-world/backend/src/utils/helper_functions.py
+++ b/custom-frontend/dynamic-yolo-world/backend/src/utils/helper_functions.py
@@ -36,10 +36,13 @@ def extract_text_embeddings(class_names, max_num_classes=80):
         save_path="tokenizer.json",
     )
     tokenizer = Tokenizer.from_file(tokenizer_json_path)
+    tokenizer.enable_padding(
+        pad_id=tokenizer.token_to_id("<|endoftext|>"), pad_token="<|endoftext|>"
+    )
     encodings = tokenizer.encode_batch(class_names)
 
     text_onnx = np.array([e.ids for e in encodings], dtype=np.int64)
-    attention_mask = (text_onnx != 0).astype(np.int64)
+    attention_mask = np.array([e.attention_mask for e in encodings], dtype=np.int64)
 
     textual_onnx_model_path = download_model(
         "https://huggingface.co/jmzzomg/clip-vit-base-patch32-text-onnx/resolve/main/model.onnx",

--- a/neural-networks/object-detection/yolo-world/utils/helper_functions.py
+++ b/neural-networks/object-detection/yolo-world/utils/helper_functions.py
@@ -13,11 +13,15 @@ def extract_text_embeddings(class_names, max_num_classes=80):
         url="https://huggingface.co/openai/clip-vit-base-patch32/resolve/main/tokenizer.json",
         save_path="tokenizer.json",
     )
+
     tokenizer = Tokenizer.from_file(tokenizer_json_path)
+    tokenizer.enable_padding(
+        pad_id=tokenizer.token_to_id("<|endoftext|>"), pad_token="<|endoftext|>"
+    )
     encodings = tokenizer.encode_batch(class_names)
 
     text_onnx = np.array([e.ids for e in encodings], dtype=np.int64)
-    attention_mask = (text_onnx != 0).astype(np.int64)
+    attention_mask = np.array([e.attention_mask for e in encodings], dtype=np.int64)
 
     textual_onnx_model_path = download_model(
         "https://huggingface.co/jmzzomg/clip-vit-base-patch32-text-onnx/resolve/main/model.onnx",


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fixed edge case where padding was not applied correctly in the new `tokenizers` code.
Tested with previously failing example:
`class_names = ["a", "airplane", "refrigerator", "dog", "microwave oven", "cup"]`

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable