### PR TITLE
Update dai requirements

### DIFF
--- a/apps/conference-demos/rgb-depth-connections/requirements.txt
+++ b/apps/conference-demos/rgb-depth-connections/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc3
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python==4.10.0.84
 numpy>=1.22

--- a/apps/default-app/requirements.txt
+++ b/apps/default-app/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python-headless==4.10.0.84
 numpy>=1.22

--- a/camera-controls/depth-driven-focus/requirements.txt
+++ b/camera-controls/depth-driven-focus/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/camera-controls/lossless-zooming/requirements.txt
+++ b/camera-controls/lossless-zooming/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4

--- a/camera-controls/manual-camera-control/requirements.txt
+++ b/camera-controls/manual-camera-control/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 opencv-python-headless~=4.10.0

--- a/custom-frontend/dynamic-yolo-world/backend/src/requirements.txt
+++ b/custom-frontend/dynamic-yolo-world/backend/src/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/custom-frontend/raw-stream/requirements.txt
+++ b/custom-frontend/raw-stream/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 numpy>=1.22

--- a/depth-measurement/3d-measurement/box-measurement/requirements.txt
+++ b/depth-measurement/3d-measurement/box-measurement/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc3
+depthai==3.0.0
 depthai-nodes==0.3.4
 numpy>=1.22
 open3d~=0.18

--- a/depth-measurement/3d-measurement/rgbd-pointcloud/requirements.txt
+++ b/depth-measurement/3d-measurement/rgbd-pointcloud/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 numpy>=1.22

--- a/depth-measurement/calc-spatial-on-host/requirements.txt
+++ b/depth-measurement/calc-spatial-on-host/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python-headless==4.10.0.84
 numpy>=1.22

--- a/depth-measurement/stereo-on-host/requirements.txt
+++ b/depth-measurement/stereo-on-host/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python-headless~=4.10.0
 scikit-image

--- a/depth-measurement/stereo-runtime-configuration/requirements.txt
+++ b/depth-measurement/stereo-runtime-configuration/requirements.txt
@@ -1,3 +1,3 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python-headless~=4.10.0

--- a/depth-measurement/triangulation/requirements.txt
+++ b/depth-measurement/triangulation/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/depth-measurement/wls-filter/requirements.txt
+++ b/depth-measurement/wls-filter/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-contrib-python==4.10.0.84
 numpy>=1.22

--- a/integrations/foxglove/requirements.txt
+++ b/integrations/foxglove/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 opencv-python-headless~=4.10.0
 foxglove-websocket==0.1.2
 numpy>=1.22

--- a/integrations/hub-snaps-events/requirements.txt
+++ b/integrations/hub-snaps-events/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 python-dotenv
 

--- a/integrations/rerun/requirements.txt
+++ b/integrations/rerun/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/integrations/roboflow-integration/README.md
+++ b/integrations/roboflow-integration/README.md
@@ -27,7 +27,7 @@ Here is a list of all available parameters:
                         private API key copied from app.roboflow.com (default: None)
   --workspace WORKSPACE
                         Name of the workspace in app.roboflow.com (default: None)
-  --dataset DATASET     Name of the project in app.roboflow.com (default: None)
+  --dataset DATASET     Project ID in app.roboflow.com (default: None)
   --auto-interval AUTO_INTERVAL
                         Automatically upload annotations every [SECONDS] seconds (default: None)
   --auto-threshold AUTO_THRESHOLD

--- a/integrations/roboflow-integration/requirements.txt
+++ b/integrations/roboflow-integration/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 numpy>=1.22
 opencv-python-headless~=4.10.0

--- a/neural-networks/3D-detection/objectron/requirements.txt
+++ b/neural-networks/3D-detection/objectron/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4

--- a/neural-networks/counting/crowdcounting/requirements.txt
+++ b/neural-networks/counting/crowdcounting/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc4
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/counting/cumulative-object-counting/requirements.txt
+++ b/neural-networks/counting/cumulative-object-counting/requirements.txt
@@ -1,3 +1,3 @@
-depthai==3.0.0rc4
+depthai==3.0.0
 depthai-nodes==0.3.4
 numpy>=1.22

--- a/neural-networks/counting/people-counter/requirements.txt
+++ b/neural-networks/counting/people-counter/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc4
+depthai==3.0.0
 depthai-nodes==0.3.4

--- a/neural-networks/depth-estimation/crestereo-stereo-matching/requirements.txt
+++ b/neural-networks/depth-estimation/crestereo-stereo-matching/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/depth-estimation/foundation-stereo/requirements.txt
+++ b/neural-networks/depth-estimation/foundation-stereo/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc4
+depthai==3.0.0
 depthai-nodes==0.3.4
 onnxruntime>=1.19.0
 onnxruntime-gpu>=1.19.0

--- a/neural-networks/face-detection/age-gender/requirements.txt
+++ b/neural-networks/face-detection/age-gender/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4

--- a/neural-networks/face-detection/blur-faces/requirements.txt
+++ b/neural-networks/face-detection/blur-faces/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/face-detection/emotion-recognition/requirements.txt
+++ b/neural-networks/face-detection/emotion-recognition/requirements.txt
@@ -1,3 +1,3 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 numpy>=1.22

--- a/neural-networks/face-detection/face-mask-detection/requirements.txt
+++ b/neural-networks/face-detection/face-mask-detection/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4

--- a/neural-networks/face-detection/fatigue-detection/requirements.txt
+++ b/neural-networks/face-detection/fatigue-detection/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/face-detection/gaze-estimation/requirements.txt
+++ b/neural-networks/face-detection/gaze-estimation/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc3
+depthai==3.0.0
 depthai-nodes==0.3.4

--- a/neural-networks/face-detection/head-posture-detection/requirements.txt
+++ b/neural-networks/face-detection/head-posture-detection/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4

--- a/neural-networks/feature-detection/xfeat/requirements.txt
+++ b/neural-networks/feature-detection/xfeat/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/generic-example/requirements.txt
+++ b/neural-networks/generic-example/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/object-detection/human-machine-safety/requirements.txt
+++ b/neural-networks/object-detection/human-machine-safety/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4

--- a/neural-networks/object-detection/social-distancing/requirements.txt
+++ b/neural-networks/object-detection/social-distancing/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/object-detection/spatial-detections/requirements.txt
+++ b/neural-networks/object-detection/spatial-detections/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4

--- a/neural-networks/object-detection/text-blur/requirements.txt
+++ b/neural-networks/object-detection/text-blur/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/object-detection/thermal-detection/requirements.txt
+++ b/neural-networks/object-detection/thermal-detection/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4

--- a/neural-networks/object-detection/yolo-host-decoding/requirements.txt
+++ b/neural-networks/object-detection/yolo-host-decoding/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 numpy>=1.22

--- a/neural-networks/object-detection/yolo-p/requirements.txt
+++ b/neural-networks/object-detection/yolo-p/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/object-detection/yolo-world/requirements.txt
+++ b/neural-networks/object-detection/yolo-world/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/object-tracking/collision-avoidance/requirements.txt
+++ b/neural-networks/object-tracking/collision-avoidance/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc4
+depthai==3.0.0
 depthai-nodes==0.3.4

--- a/neural-networks/object-tracking/deepsort-tracking/requirements.txt
+++ b/neural-networks/object-tracking/deepsort-tracking/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc4
+depthai==3.0.0
 depthai-nodes==0.3.4
 numpy>=1.22
 opencv-python-headless~=4.10.0

--- a/neural-networks/object-tracking/kalman/requirements.txt
+++ b/neural-networks/object-tracking/kalman/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc4
+depthai==3.0.0
 depthai-nodes==0.3.4

--- a/neural-networks/object-tracking/people-tracker/requirements.txt
+++ b/neural-networks/object-tracking/people-tracker/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc4
+depthai==3.0.0
 depthai-nodes==0.3.4

--- a/neural-networks/ocr/general-ocr/requirements.txt
+++ b/neural-networks/ocr/general-ocr/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python-headless==4.10.0.84
 numpy>=1.22

--- a/neural-networks/ocr/license-plate-recognition/requirements.txt
+++ b/neural-networks/ocr/license-plate-recognition/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/pose-estimation/animal-pose/requirements.txt
+++ b/neural-networks/pose-estimation/animal-pose/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4

--- a/neural-networks/pose-estimation/hand-pose/requirements.txt
+++ b/neural-networks/pose-estimation/hand-pose/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4

--- a/neural-networks/pose-estimation/human-pose/requirements.txt
+++ b/neural-networks/pose-estimation/human-pose/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4

--- a/neural-networks/reidentification/human-reidentification/requirements.txt
+++ b/neural-networks/reidentification/human-reidentification/requirements.txt
@@ -1,3 +1,3 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 numpy>=1.22

--- a/neural-networks/segmentation/blur-background/requirements.txt
+++ b/neural-networks/segmentation/blur-background/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/segmentation/depth-crop/requirements.txt
+++ b/neural-networks/segmentation/depth-crop/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4

--- a/neural-networks/speech-recognition/whisper-tiny-en/requirements.txt
+++ b/neural-networks/speech-recognition/whisper-tiny-en/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 numpy>=1.22
 scipy

--- a/streaming/mjpeg-streaming/requirements.txt
+++ b/streaming/mjpeg-streaming/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/streaming/on-device-encoding/requirements.txt
+++ b/streaming/on-device-encoding/requirements.txt
@@ -1,3 +1,3 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 av==12.3.0
 numpy>=1.22

--- a/streaming/poe-mqtt/requirements.txt
+++ b/streaming/poe-mqtt/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4

--- a/streaming/poe-tcp-streaming/requirements.txt
+++ b/streaming/poe-tcp-streaming/requirements.txt
@@ -1,3 +1,3 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 opencv-python~=4.10.0
 numpy>=1.22

--- a/streaming/rtsp-streaming/requirements.txt
+++ b/streaming/rtsp-streaming/requirements.txt
@@ -1,3 +1,3 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 numpy>=1.22
 PyGObject==3.46.0

--- a/streaming/webrtc-streaming/requirements.txt
+++ b/streaming/webrtc-streaming/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 aiortc==1.9.0
 aiohttp>=3.10.0,<4.0

--- a/tutorials/camera-demo/requirements.txt
+++ b/tutorials/camera-demo/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 numpy>=1.22

--- a/tutorials/camera-stereo-depth/main.py
+++ b/tutorials/camera-stereo-depth/main.py
@@ -35,6 +35,7 @@ with dai.Pipeline(device) as pipeline:
         right=right_output,
     )
 
+    stereo.initialConfig.setMedianFilter(dai.MedianFilter.MEDIAN_OFF)
     stereo.setRectification(True)
     stereo.setExtendedDisparity(True)
     stereo.setLeftRightCheck(True)

--- a/tutorials/camera-stereo-depth/requirements.txt
+++ b/tutorials/camera-stereo-depth/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 numpy>=1.22
 opencv-python-headless~=4.10.0

--- a/tutorials/custom-models/generate_model/requirements.txt
+++ b/tutorials/custom-models/generate_model/requirements.txt
@@ -1,5 +1,5 @@
 /
-depthai==3.0.0rc2
+depthai==3.0.0
 modelconv==0.3.3
 numpy==1.23.0
 onnx==1.17.0

--- a/tutorials/custom-models/requirements.txt
+++ b/tutorials/custom-models/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 numpy>=1.22
 opencv-python-headless~=4.10.0

--- a/tutorials/display-detections/requirements.txt
+++ b/tutorials/display-detections/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 numpy>=1.22
 opencv-python-headless~=4.10.0

--- a/tutorials/full-fov-nn/requirements.txt
+++ b/tutorials/full-fov-nn/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4

--- a/tutorials/multiple-devices/multi-cam-calibration/requirements.txt
+++ b/tutorials/multiple-devices/multi-cam-calibration/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python==4.10.0.84
 numpy>=1.22

--- a/tutorials/multiple-devices/multiple-devices-preview/requirements.txt
+++ b/tutorials/multiple-devices/multiple-devices-preview/requirements.txt
@@ -1,2 +1,2 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4

--- a/tutorials/multiple-devices/spatial-detection-fusion/requirements.txt
+++ b/tutorials/multiple-devices/spatial-detection-fusion/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 opencv-python-headless==4.10.0.84
 numpy>=1.22

--- a/tutorials/play-encoded-stream/requirements.txt
+++ b/tutorials/play-encoded-stream/requirements.txt
@@ -1,3 +1,3 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 opencv-python-headless~=4.10.0
 av==12.3.0

--- a/tutorials/qr-with-tiling/requirements.txt
+++ b/tutorials/qr-with-tiling/requirements.txt
@@ -1,4 +1,4 @@
-depthai==3.0.0rc2
+depthai==3.0.0
 depthai-nodes==0.3.4
 numpy>=1.22
 pyzbar==0.1.9


### PR DESCRIPTION
## Purpose
- Update depthai version requirements in the oak-examples from release candidates versions to 3.0.0
- Update tutorials/camera-stereo-depth example to no longer use median filter

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
- Examples were tested again with updated depthai version