### PR TITLE
locked numpy version to 1.26.4 and o3d 0.18.0 to avoid module conflicts

### DIFF
--- a/depth-measurement/3d-measurement/box-measurement/requirements.txt
+++ b/depth-measurement/3d-measurement/box-measurement/requirements.txt
@@ -1,5 +1,5 @@
 depthai==3.8.0
 depthai-nodes==0.5.0
-numpy>=1.22
-open3d~=0.18
+numpy==1.26.4
+open3d==0.18.0
 opencv-python-headless==4.10.0.84


### PR DESCRIPTION
## Purpose
When performing o3d / numpy operation the example would often segfault due to version incompatibilities.
This would result in the program crahsing when seeing a box.

## Specification
Locked numpy and o3d versions to those that are compatible with eachother.
numpy == 1.26.4 and o3d == 0.18.0

## AI Usage
Chatgpt told me the versions

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES
