### PR TITLE
Bump to depthai-nodes v0.6.0

### DIFF
--- a/apps/conference-demos/rgb-depth-connections/requirements.txt
+++ b/apps/conference-demos/rgb-depth-connections/requirements.txt
@@ -1,3 +1,3 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python==4.10.0.84

--- a/apps/data-collection/backend/requirements.txt
+++ b/apps/data-collection/backend/requirements.txt
@@ -1,5 +1,5 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless~=4.10.0
 tokenizers~=0.21.0
 onnxruntime

--- a/apps/default-app/requirements.txt
+++ b/apps/default-app/requirements.txt
@@ -1,3 +1,3 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless==4.10.0.84

--- a/apps/focused-vision/backend/requirements.txt
+++ b/apps/focused-vision/backend/requirements.txt
@@ -1,3 +1,3 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless==4.10.0.84

--- a/apps/object-volume-measurement-3d/backend/requirements.txt
+++ b/apps/object-volume-measurement-3d/backend/requirements.txt
@@ -1,5 +1,5 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless~=4.10.0
 numpy>=1.22
 tokenizers~=0.21.0

--- a/apps/p2p-measurement/backend/requirements.txt
+++ b/apps/p2p-measurement/backend/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-contrib-python==4.12.0.88
 numpy>=1.22

--- a/apps/people-demographics-and-sentiment-analysis/backend/requirements.txt
+++ b/apps/people-demographics-and-sentiment-analysis/backend/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 numpy==2.2.6
 opencv-python-headless==4.10.0.84

--- a/apps/qr-tiling/backend/requirements.txt
+++ b/apps/qr-tiling/backend/requirements.txt
@@ -1,5 +1,5 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 numpy>=1.22
 pyzbar==0.1.9
 pydantic

--- a/camera-controls/depth-driven-focus/requirements.txt
+++ b/camera-controls/depth-driven-focus/requirements.txt
@@ -1,3 +1,3 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless~=4.10.0

--- a/camera-controls/lossless-zooming/requirements.txt
+++ b/camera-controls/lossless-zooming/requirements.txt
@@ -1,2 +1,2 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0

--- a/camera-controls/manual-camera-control/requirements.txt
+++ b/camera-controls/manual-camera-control/requirements.txt
@@ -1,3 +1,3 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless~=4.10.0

--- a/custom-frontend/open-vocabulary-object-detection/backend/requirements.txt
+++ b/custom-frontend/open-vocabulary-object-detection/backend/requirements.txt
@@ -1,5 +1,5 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless~=4.10.0
 numpy>=1.22
 tokenizers~=0.21.0

--- a/custom-frontend/raw-stream/requirements.txt
+++ b/custom-frontend/raw-stream/requirements.txt
@@ -1,3 +1,3 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 numpy>=1.22

--- a/depth-measurement/3d-measurement/box-measurement/requirements.txt
+++ b/depth-measurement/3d-measurement/box-measurement/requirements.txt
@@ -1,5 +1,5 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 numpy>=1.22
 open3d~=0.18
 opencv-python-headless==4.10.0.84

--- a/depth-measurement/3d-measurement/rgbd-pointcloud/requirements.txt
+++ b/depth-measurement/3d-measurement/rgbd-pointcloud/requirements.txt
@@ -1,3 +1,3 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 numpy>=1.22

--- a/depth-measurement/3d-measurement/tof-pointcloud/requirements.txt
+++ b/depth-measurement/3d-measurement/tof-pointcloud/requirements.txt
@@ -1,5 +1,5 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 numpy>=1.22
 open3d~=0.18
 opencv-python~=4.10.0

--- a/depth-measurement/calc-spatial-on-host/requirements.txt
+++ b/depth-measurement/calc-spatial-on-host/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless==4.10.0.84
 numpy>=1.22

--- a/depth-measurement/dynamic-calibration/requirements.txt
+++ b/depth-measurement/dynamic-calibration/requirements.txt
@@ -1,5 +1,5 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 numpy>=1.22
 opencv-python==4.10.0.84
 opencv-contrib-python==4.10.0.84

--- a/depth-measurement/stereo-on-host/requirements.txt
+++ b/depth-measurement/stereo-on-host/requirements.txt
@@ -1,5 +1,5 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless~=4.10.0
 scikit-image
 numpy>=1.22

--- a/depth-measurement/stereo-runtime-configuration/requirements.txt
+++ b/depth-measurement/stereo-runtime-configuration/requirements.txt
@@ -1,3 +1,3 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless~=4.10.0

--- a/depth-measurement/triangulation/requirements.txt
+++ b/depth-measurement/triangulation/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/depth-measurement/wls-filter/requirements.txt
+++ b/depth-measurement/wls-filter/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-contrib-python==4.10.0.84
 numpy>=1.22

--- a/integrations/foxglove/requirements.txt
+++ b/integrations/foxglove/requirements.txt
@@ -1,5 +1,5 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless~=4.10.0
 foxglove-websocket==0.1.2
 numpy>=1.22

--- a/integrations/hub-snaps-events/requirements.txt
+++ b/integrations/hub-snaps-events/requirements.txt
@@ -1,3 +1,3 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 python-dotenv

--- a/integrations/rerun/requirements.txt
+++ b/integrations/rerun/requirements.txt
@@ -1,5 +1,5 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless~=4.10.0
 numpy>=1.22
 rerun-sdk==0.15.1

--- a/integrations/roboflow-dataset/requirements.txt
+++ b/integrations/roboflow-dataset/requirements.txt
@@ -1,5 +1,5 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 numpy>=1.22
 opencv-python-headless~=4.10.0
 roboflow==1.1.36

--- a/integrations/roboflow-workflow/backend/src/requirements.txt
+++ b/integrations/roboflow-workflow/backend/src/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python~=4.10.0
 inference

--- a/neural-networks/3D-detection/objectron/requirements.txt
+++ b/neural-networks/3D-detection/objectron/requirements.txt
@@ -1,2 +1,2 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0

--- a/neural-networks/counting/crowdcounting/requirements.txt
+++ b/neural-networks/counting/crowdcounting/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/counting/cumulative-object-counting/requirements.txt
+++ b/neural-networks/counting/cumulative-object-counting/requirements.txt
@@ -1,3 +1,3 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 numpy>=1.22

--- a/neural-networks/counting/depth-people-counting/requirements.txt
+++ b/neural-networks/counting/depth-people-counting/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/counting/people-counter/requirements.txt
+++ b/neural-networks/counting/people-counter/requirements.txt
@@ -1,2 +1,2 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0

--- a/neural-networks/depth-estimation/crestereo-stereo-matching/requirements.txt
+++ b/neural-networks/depth-estimation/crestereo-stereo-matching/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/depth-estimation/foundation-stereo/requirements.txt
+++ b/neural-networks/depth-estimation/foundation-stereo/requirements.txt
@@ -1,5 +1,5 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 onnxruntime>=1.19.0
 onnxruntime-gpu>=1.19.0
 numpy>=1.22

--- a/neural-networks/depth-estimation/neural-depth/host_eval/requirements.txt
+++ b/neural-networks/depth-estimation/neural-depth/host_eval/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4==4.12.3
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 numpy
 opencv-python~=4.10.0
 requests

--- a/neural-networks/depth-estimation/neural-depth/requirements.txt
+++ b/neural-networks/depth-estimation/neural-depth/requirements.txt
@@ -1,2 +1,2 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0

--- a/neural-networks/face-detection/age-gender/requirements.txt
+++ b/neural-networks/face-detection/age-gender/requirements.txt
@@ -1,2 +1,2 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0

--- a/neural-networks/face-detection/blur-faces/requirements.txt
+++ b/neural-networks/face-detection/blur-faces/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/face-detection/emotion-recognition/requirements.txt
+++ b/neural-networks/face-detection/emotion-recognition/requirements.txt
@@ -1,3 +1,3 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 numpy>=1.22

--- a/neural-networks/face-detection/face-mask-detection/requirements.txt
+++ b/neural-networks/face-detection/face-mask-detection/requirements.txt
@@ -1,2 +1,2 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0

--- a/neural-networks/face-detection/fatigue-detection/requirements.txt
+++ b/neural-networks/face-detection/fatigue-detection/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/face-detection/gaze-estimation/requirements.txt
+++ b/neural-networks/face-detection/gaze-estimation/requirements.txt
@@ -1,2 +1,2 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0

--- a/neural-networks/face-detection/head-posture-detection/requirements.txt
+++ b/neural-networks/face-detection/head-posture-detection/requirements.txt
@@ -1,2 +1,2 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0

--- a/neural-networks/feature-detection/xfeat/requirements.txt
+++ b/neural-networks/feature-detection/xfeat/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/object-detection/barcode-detection-conveyor-belt/requirements.txt
+++ b/neural-networks/object-detection/barcode-detection-conveyor-belt/requirements.txt
@@ -1,5 +1,5 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 numpy>=1.22
 opencv-python-headless~=4.10.0
 pyzbar==0.1.9

--- a/neural-networks/object-detection/human-machine-safety/requirements.txt
+++ b/neural-networks/object-detection/human-machine-safety/requirements.txt
@@ -1,2 +1,2 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0

--- a/neural-networks/object-detection/social-distancing/requirements.txt
+++ b/neural-networks/object-detection/social-distancing/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/object-detection/spatial-detections/requirements.txt
+++ b/neural-networks/object-detection/spatial-detections/requirements.txt
@@ -1,2 +1,2 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0

--- a/neural-networks/object-detection/text-blur/requirements.txt
+++ b/neural-networks/object-detection/text-blur/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/object-detection/thermal-detection/requirements.txt
+++ b/neural-networks/object-detection/thermal-detection/requirements.txt
@@ -1,2 +1,2 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0

--- a/neural-networks/object-detection/yolo-host-decoding/requirements.txt
+++ b/neural-networks/object-detection/yolo-host-decoding/requirements.txt
@@ -1,3 +1,3 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 numpy>=1.22

--- a/neural-networks/object-detection/yolo-world/requirements.txt
+++ b/neural-networks/object-detection/yolo-world/requirements.txt
@@ -1,5 +1,5 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless~=4.10.0
 numpy>=1.22
 onnxruntime

--- a/neural-networks/object-tracking/collision-avoidance/requirements.txt
+++ b/neural-networks/object-tracking/collision-avoidance/requirements.txt
@@ -1,2 +1,2 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0

--- a/neural-networks/object-tracking/deepsort-tracking/requirements.txt
+++ b/neural-networks/object-tracking/deepsort-tracking/requirements.txt
@@ -1,5 +1,5 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 numpy>=1.22
 opencv-python-headless~=4.10.0
 scipy

--- a/neural-networks/object-tracking/kalman/requirements.txt
+++ b/neural-networks/object-tracking/kalman/requirements.txt
@@ -1,2 +1,2 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0

--- a/neural-networks/object-tracking/people-tracker/requirements.txt
+++ b/neural-networks/object-tracking/people-tracker/requirements.txt
@@ -1,2 +1,2 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0

--- a/neural-networks/ocr/general-ocr/requirements.txt
+++ b/neural-networks/ocr/general-ocr/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless==4.10.0.84
 numpy>=1.22

--- a/neural-networks/ocr/license-plate-recognition/requirements.txt
+++ b/neural-networks/ocr/license-plate-recognition/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/neural-networks/pose-estimation/animal-pose/requirements.txt
+++ b/neural-networks/pose-estimation/animal-pose/requirements.txt
@@ -1,2 +1,2 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0

--- a/neural-networks/pose-estimation/hand-pose/requirements.txt
+++ b/neural-networks/pose-estimation/hand-pose/requirements.txt
@@ -1,2 +1,2 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0

--- a/neural-networks/pose-estimation/human-pose/requirements.txt
+++ b/neural-networks/pose-estimation/human-pose/requirements.txt
@@ -1,2 +1,2 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0

--- a/neural-networks/reidentification/human-reidentification/requirements.txt
+++ b/neural-networks/reidentification/human-reidentification/requirements.txt
@@ -1,3 +1,3 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 numpy>=1.22

--- a/neural-networks/speech-recognition/whisper-tiny-en/requirements.txt
+++ b/neural-networks/speech-recognition/whisper-tiny-en/requirements.txt
@@ -1,5 +1,5 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 numpy>=1.22
 scipy
 tqdm

--- a/streaming/mjpeg-streaming/requirements.txt
+++ b/streaming/mjpeg-streaming/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/streaming/on-device-encoding/requirements.txt
+++ b/streaming/on-device-encoding/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 av==12.3.0
 numpy>=1.22

--- a/streaming/poe-mqtt/requirements.txt
+++ b/streaming/poe-mqtt/requirements.txt
@@ -1,2 +1,2 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0

--- a/streaming/poe-tcp-streaming/requirements.txt
+++ b/streaming/poe-tcp-streaming/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python~=4.10.0
 numpy>=1.22

--- a/streaming/rtsp-streaming/requirements.txt
+++ b/streaming/rtsp-streaming/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 numpy>=1.22
 PyGObject==3.46.0

--- a/streaming/webrtc-streaming/requirements.txt
+++ b/streaming/webrtc-streaming/requirements.txt
@@ -1,5 +1,5 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 aiortc==1.9.0
 aiohttp>=3.10.0,<4.0
 aiohttp-cors==0.7.0

--- a/tutorials/camera-demo/requirements.txt
+++ b/tutorials/camera-demo/requirements.txt
@@ -1,3 +1,3 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 numpy>=1.22

--- a/tutorials/camera-stereo-depth/requirements.txt
+++ b/tutorials/camera-stereo-depth/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 numpy>=1.22
 opencv-python-headless~=4.10.0

--- a/tutorials/custom-models/generate_model/requirements.txt
+++ b/tutorials/custom-models/generate_model/requirements.txt
@@ -1,6 +1,6 @@
 /
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 modelconv==0.3.3
 numpy==1.23.0
 onnx==1.17.0

--- a/tutorials/custom-models/requirements.txt
+++ b/tutorials/custom-models/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 numpy>=1.22
 opencv-python-headless~=4.10.0

--- a/tutorials/display-detections/requirements.txt
+++ b/tutorials/display-detections/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 numpy>=1.22
 opencv-python-headless~=4.10.0

--- a/tutorials/full-fov-nn/requirements.txt
+++ b/tutorials/full-fov-nn/requirements.txt
@@ -1,2 +1,2 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0

--- a/tutorials/multiple-devices/multi-cam-calibration/requirements.txt
+++ b/tutorials/multiple-devices/multi-cam-calibration/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python==4.10.0.84
 numpy>=1.22

--- a/tutorials/multiple-devices/multiple-device-stitch-nn/requirements.txt
+++ b/tutorials/multiple-devices/multiple-device-stitch-nn/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 imutils
 stitching==0.6.1

--- a/tutorials/multiple-devices/multiple-devices-preview/requirements.txt
+++ b/tutorials/multiple-devices/multiple-devices-preview/requirements.txt
@@ -1,2 +1,2 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0

--- a/tutorials/multiple-devices/spatial-detection-fusion/requirements.txt
+++ b/tutorials/multiple-devices/spatial-detection-fusion/requirements.txt
@@ -1,5 +1,5 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless==4.10.0.84
 numpy>=1.22
 scipy

--- a/tutorials/play-encoded-stream/requirements.txt
+++ b/tutorials/play-encoded-stream/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 opencv-python-headless~=4.10.0
 av==12.3.0

--- a/tutorials/qr-with-tiling/requirements.txt
+++ b/tutorials/qr-with-tiling/requirements.txt
@@ -1,4 +1,4 @@
 depthai==3.8.0
-depthai-nodes==0.5.0
+depthai-nodes==0.6.0
 numpy>=1.22
 pyzbar==0.1.9


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
- Bumps the depthai-nodes dependency on all relevant examples to v0.6.0
  - 0.6.0 mainly introduced one breaking change related to dai.SegmentationMask but that one was already separately handled in https://github.com/luxonis/oak-examples/pull/850 so this should result in no practical change for the rest of the examples

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO
