### PR TITLE
Support frontend/backend OAK Apps in standalone test collection

### DIFF
--- a/.github/workflows/tests_diff.yml
+++ b/.github/workflows/tests_diff.yml
@@ -129,7 +129,11 @@ jobs:
           while read -r file; do
             dir=$(dirname "$file")
             while [ "$dir" != "." ] && [ "$dir" != "/" ]; do
-              if [[ -f "$dir/main.py" && -f "$dir/requirements.txt" ]]; then
+              if [[
+                -f "$dir/oakapp.toml" &&
+                -f "$dir/backend/src/main.py" &&
+                ( -f "$dir/backend/requirements.txt" || -f "$dir/backend/src/requirements.txt" )
+              ]] || [[ -f "$dir/main.py" && -f "$dir/requirements.txt" ]]; then
                 example_dirs="$example_dirs $dir"
                 break
               fi

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,11 +127,29 @@ def pytest_generate_tests(metafunc):
     if "example_dir" in metafunc.fixturenames:
         root_dirs = metafunc.config.getoption("--root-dir")
         exp_dirs = set()  # Use a set to avoid duplicates
+        is_standalone_test = metafunc.module.__name__ == "test_examples_standalone"
 
         for root_dir in root_dirs:
             for dirpath, dirnames, filenames in os.walk(root_dir):
+                example_dir = Path(dirpath)
+                backend_dir = example_dir / "backend"
+                backend_requirements = (
+                    backend_dir / "requirements.txt",
+                    backend_dir / "src" / "requirements.txt",
+                )
+                if (
+                    is_standalone_test
+                    and "oakapp.toml" in filenames
+                    and any(path.is_file() for path in backend_requirements)
+                    and (backend_dir / "src" / "main.py").is_file()
+                ):
+                    exp_dirs.add(example_dir)
+                    if "backend" in dirnames:
+                        dirnames.remove("backend")
+                    continue
+
                 if "main.py" in filenames and "requirements.txt" in filenames:
-                    exp_dirs.add(Path(dirpath))
+                    exp_dirs.add(example_dir)
                 elif "main.py" in filenames and "requirements.txt" not in filenames:
                     logger.info(
                         f"Skipping {dirpath} because it has no requirements.txt"

--- a/tests/test_examples_peripheral.py
+++ b/tests/test_examples_peripheral.py
@@ -20,12 +20,6 @@ logging.basicConfig(level=logging.INFO)
 
 def test_example_runs_in_peripheral(example_dir, test_args):
     """Tests if the example runs in peripheral mode for at least N seconds without errors."""
-    # Time that device is waiting before timing out, set for RVC4 tests
-    os.environ["DEPTHAI_SEARCH_TIMEOUT"] = "30000"
-
-    if test_args["virtual_display"]:
-        setup_virtual_display()
-
     example_dir = example_dir.resolve()
 
     success, reason = is_valid(
@@ -38,6 +32,12 @@ def test_example_runs_in_peripheral(example_dir, test_args):
     )
     if not success:
         pytest.skip(f"Skipping {example_dir}: {reason}")
+
+    # Time that device is waiting before timing out, set for RVC4 tests
+    os.environ["DEPTHAI_SEARCH_TIMEOUT"] = "30000"
+
+    if test_args["virtual_display"]:
+        setup_virtual_display()
 
     main_script = example_dir / "main.py"
     requirements_path = example_dir / "requirements.txt"

--- a/tests/test_examples_standalone.py
+++ b/tests/test_examples_standalone.py
@@ -36,9 +36,6 @@ def skip_if_not_rvc4(test_args):
 
 def test_example_runs_in_standalone(example_dir, example_test_args):
     """Tests if the example runs in standalone mode for at least N seconds without errors."""
-    # Time that device is waiting before timing out, set for RVC4 tests
-    os.environ["DEPTHAI_SEARCH_TIMEOUT"] = "30000"
-
     example_dir = example_dir.resolve()
 
     success, reason = is_valid(
@@ -52,31 +49,45 @@ def test_example_runs_in_standalone(example_dir, example_test_args):
     if not success:
         pytest.skip(f"Skipping {example_dir}: {reason}")
 
+    # Time that device is waiting before timing out, set for RVC4 tests
+    os.environ["DEPTHAI_SEARCH_TIMEOUT"] = "30000"
+
     main_script = example_dir / "main.py"
     requirements_path = example_dir / "requirements.txt"
     oakapp_toml = example_dir / "oakapp.toml"
 
-    if not oakapp_toml.exists():
+    if not (
+        oakapp_toml.exists() and main_script.exists() and requirements_path.exists()
+    ):
         logger.debug(
-            "Checking for oakapp.toml in fallback location. Expected example structure: <root>/oakapp.toml and <root>/backend/src/."
+            "Checking for a frontend/backend standalone app layout. Expected layout: "
+            "<root>/oakapp.toml, <root>/backend/requirements.txt, and "
+            "<root>/backend/src/main.py."
         )
-        # try fallback: oakapp.toml two levels up
-        candidate_root = example_dir.parents[1]
+        candidate_root = example_dir if oakapp_toml.exists() else example_dir.parents[1]
         fallback_oak = candidate_root / "oakapp.toml"
-
-        # expect structure: <root>/oakapp.toml and <root>/backend/src/
         fallback_main = candidate_root / "backend" / "src" / "main.py"
-        fallback_req = candidate_root / "backend" / "src" / "requirements.txt"
+        fallback_requirements = next(
+            (
+                path
+                for path in (
+                    candidate_root / "backend" / "requirements.txt",
+                    candidate_root / "backend" / "src" / "requirements.txt",
+                )
+                if path.exists()
+            ),
+            None,
+        )
 
-        if fallback_oak.exists() and fallback_main.exists() and fallback_req.exists():
-            logger.debug("Fallback example structure confirmed.")
+        if fallback_oak.exists() and fallback_main.exists() and fallback_requirements:
+            logger.debug("Frontend/backend standalone app layout confirmed.")
             oakapp_toml = fallback_oak
             main_script = fallback_main
-            requirements_path = fallback_req
+            requirements_path = fallback_requirements
             example_dir = candidate_root
         else:
             pytest.skip(
-                f"Skipping {example_dir}, no oakapp.toml found in expected locations."
+                f"Skipping {example_dir}, no compatible standalone app layout found."
             )
 
     if not main_script.exists():


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

Add standalone test support for frontend/backend OAK Apps that use `oakapp.toml`, `backend/src/main.py`, and requirements under `backend/` or `backend/src/`.

- Collect these apps for standalone tests only; peripheral tests continue to ignore them.
- Update standalone path resolution for this layout.
- Extend changed-example detection so affected apps trigger standalone CI.
- Move test environment setup after eligibility filtering.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO
