### PR TITLE
Fix gaze estimation device timestamp propagation

### DIFF
--- a/neural-networks/face-detection/gaze-estimation/AGENTS.md
+++ b/neural-networks/face-detection/gaze-estimation/AGENTS.md
@@ -50,6 +50,7 @@ This is the repository reference for a multi-input, three-stage gaze estimation 
 ## Constraints
 
 - This is a multi-input pipeline with several blocking/max-size settings; it is much easier to break than the simpler two-stage face examples.
+- Host-created config groups, crop configs, tensors, and annotations must preserve both the source timestamp and device timestamp so downstream nodes can synchronize them with camera frames.
 - RVC4 uses a larger requested source resolution than RVC2 in [main.py](main.py).
 - Replay or camera sizing changes can invalidate the crop logic if done blindly.
 

--- a/neural-networks/face-detection/gaze-estimation/utils/annotation_node.py
+++ b/neural-networks/face-detection/gaze-estimation/utils/annotation_node.py
@@ -53,6 +53,7 @@ class AnnotationNode(dai.node.HostNode):
             timestamp=detections_msg.getTimestamp(),
             sequence_num=detections_msg.getSequenceNum(),
         )
+        annotations_msg.setTimestampDevice(detections_msg.getTimestampDevice())
 
         self.out.send(annotations_msg)
 

--- a/neural-networks/face-detection/gaze-estimation/utils/host_concatenate_head_pose.py
+++ b/neural-networks/face-detection/gaze-estimation/utils/host_concatenate_head_pose.py
@@ -41,6 +41,7 @@ class ConcatenateHeadPose(dai.node.HostNode):
 
         output_msg.addTensor("head_pose_angles_yaw_pitch_roll", output)
         output_msg.setTimestamp(ts)
+        output_msg.setTimestampDevice(yaw_msg.getTimestampDevice())
         output_msg.setSequenceNum(seq_num)
 
         self.output.send(output_msg)

--- a/neural-networks/face-detection/gaze-estimation/utils/process_keypoints.py
+++ b/neural-networks/face-detection/gaze-estimation/utils/process_keypoints.py
@@ -21,6 +21,7 @@ class LandmarksProcessing(dai.node.ThreadedHostNode):
             detections = img_detections.detections
             sequence_num = img_detections.getSequenceNum()
             timestamp = img_detections.getTimestamp()
+            timestamp_device = img_detections.getTimestampDevice()
 
             left_configs_message = dai.MessageGroup()
             right_configs_message = dai.MessageGroup()
@@ -53,12 +54,15 @@ class LandmarksProcessing(dai.node.ThreadedHostNode):
 
             left_configs_message.setSequenceNum(sequence_num)
             left_configs_message.setTimestamp(timestamp)
+            left_configs_message.setTimestampDevice(timestamp_device)
 
             right_configs_message.setSequenceNum(sequence_num)
             right_configs_message.setTimestamp(timestamp)
+            right_configs_message.setTimestampDevice(timestamp_device)
 
             face_configs_message.setSequenceNum(sequence_num)
             face_configs_message.setTimestamp(timestamp)
+            face_configs_message.setTimestampDevice(timestamp_device)
 
             self.face_config_output.send(face_configs_message)
             self.left_config_output.send(left_configs_message)
@@ -83,6 +87,7 @@ class LandmarksProcessing(dai.node.ThreadedHostNode):
         cfg.setOutputSize(self.target_w, self.target_h)
         cfg.setReusePreviousImage(False)
         cfg.setTimestamp(img_detections.getTimestamp())
+        cfg.setTimestampDevice(img_detections.getTimestampDevice())
         cfg.setSequenceNum(img_detections.getSequenceNum())
 
         return cfg


### PR DESCRIPTION
## Summary

- propagate device timestamps through gaze-estimation crop configuration groups
- preserve device timestamps on derived crop configs, head-pose tensors, and annotations
- document the timestamp requirement for future changes

## Problem

The three FrameCropper synchronization nodes received config groups with a default device timestamp of 0 ms while camera frames carried valid device timestamps. This prevented synchronization and caused continuous Sync warnings.

## Testing

- reproduced the zero-timestamp Sync warnings on an OAK4 before the fix
- ran oakctl app run neural-networks/face-detection/gaze-estimation/ on an OAK4 after the fix; no Sync warnings appeared during the observation window
- Python compileall
- AGENTS.md validation
- generated index check
- Ruff, Ruff format, and mdformat pre-commit hooks